### PR TITLE
Format amounts with no decimals without decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v1.0.2
+## Formatting amounts with no decimals without decimals
+
+Before:
+```js
+formatAmount(1234, 'gbp') // 1,234.00
+```
+
+After:
+```js
+formatAmount(1234, 'gbp') // 1,234
+```
+
 # v1.0.1
 ## Number formatting and SSR fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A library for formatting things, like dates and currencies and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/currencyFormatting.js
+++ b/src/currencyFormatting.js
@@ -47,8 +47,19 @@ function getCurrencyDecimals(currency = '') {
   return DEFAULT_CURRENCY_DECIMALS;
 }
 
+function amountHasNoDecimals(amount) {
+  return amount % 1 === 0;
+}
+
+function getPrecision(amount, currencyCode) {
+  if (amountHasNoDecimals(amount)) {
+    return 0;
+  }
+  return getCurrencyDecimals(currencyCode);
+}
+
 export function formatAmount(amount, currencyCode, locale = 'en-GB') {
-  const precision = getCurrencyDecimals(currencyCode);
+  const precision = getPrecision(amount, currencyCode);
   const isNegative = amount < 0;
   const absoluteAmount = Math.abs(amount);
 

--- a/src/currencyFormatting.spec.js
+++ b/src/currencyFormatting.spec.js
@@ -48,6 +48,10 @@ describe('Currency formatting', () => {
     expect(formatAmount(-1234.5, 'gbp')).toBe('- 1,234.50');
   });
 
+  it('formats amounts with no decimals without decimals', () => {
+    expect(formatAmount(1234, 'gbp')).toBe('1,234');
+  });
+
   it('formats money the same way as it formats amounts, but with the currency code added', () => {
     expect(formatMoney(1234.5, 'gbp')).toBe('1,234.50 GBP');
   });


### PR DESCRIPTION
# v1.0.2
## Formatting amounts with no decimals without decimals

Before:
```js
formatAmount(1234, 'gbp') // 1,234.00
```

After:
```js
formatAmount(1234, 'gbp') // 1,234
```