### PR TITLE
Fromat date default timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.3.1
+## Date default timezone not UTC
+
 # v1.3.0
 ## Formatting dates
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ console.log(formatPercentage(0.2300));
 ```javascript
 import { formatDate } from '@transferwise/formatting';
 
-const date = new Date(Date.UTC(2018, 11, 1));
+const date = new Date(2018, 11, 1);
 
 console.log(formatDate(date, 'en-GB' /* Optional, defaults to en-GB */));
 // --> '01/12/2018'
@@ -59,10 +59,6 @@ console.log(formatDate(date, 'en-GB', { month: 'long', year: 'numeric' }));
 // --> 'December 2018'
 ```
 It's basically a wrapper for `Date.toLocaleDateString`, so you can pass in the same [parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#Parameters).
-Only difference is that `timeZone` is set to `UTC` by default, to disable it go for:
-```javascript
-console.log(formatDate(date, 'en-GB', { isUTC: false }));
-```
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A library for formatting things, like dates and currencies and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/date/date.js
+++ b/src/date/date.js
@@ -4,12 +4,7 @@ import { getFallbackFormat } from './fallback-format';
 const DEFAULT_LOCALE = 'en-GB';
 
 export function formatDate(date, locale = DEFAULT_LOCALE, options = {}) {
-  const { isUTC, ...opts } = options; // extract isUTC out of options
-  // to disable UTC `isUTC` must be explicitly set to false
-  if (isUTC !== false) {
-    opts.timeZone = 'UTC';
-  }
   return isToLocaleDateStringSupported()
-    ? date.toLocaleDateString(isSelectedLocaleSupported(locale) ? locale : DEFAULT_LOCALE, opts)
-    : getFallbackFormat(date, opts);
+    ? date.toLocaleDateString(isSelectedLocaleSupported(locale) ? locale : DEFAULT_LOCALE, options)
+    : getFallbackFormat(date, options);
 }

--- a/src/date/date.spec.js
+++ b/src/date/date.spec.js
@@ -16,17 +16,12 @@ describe('Date formatting', () => {
 
     it('should call toLocaleDateString with default params', () => {
       expect(formatDate(date)).toBe('trolo');
-      expect(date.toLocaleDateString).lastCalledWith('en-GB', { timeZone: 'UTC' });
+      expect(date.toLocaleDateString).lastCalledWith('en-GB', {});
     });
 
     it('should pass given params to toLocaleDateString', () => {
       formatDate(date, 'et', { whatever: true });
-      expect(date.toLocaleDateString).lastCalledWith('et', { timeZone: 'UTC', whatever: true });
-    });
-
-    it('should not include timeZone parameter when isUTC is set to false', () => {
-      formatDate(date, 'et', { isUTC: false });
-      expect(date.toLocaleDateString).lastCalledWith('et', {});
+      expect(date.toLocaleDateString).lastCalledWith('et', { whatever: true });
     });
   });
 
@@ -38,7 +33,7 @@ describe('Date formatting', () => {
 
     it('should use default locale', () => {
       formatDate(date, 'my-awesome-locale');
-      expect(date.toLocaleDateString).lastCalledWith('en-GB', { timeZone: 'UTC' });
+      expect(date.toLocaleDateString).lastCalledWith('en-GB', {});
     });
   });
 
@@ -49,7 +44,7 @@ describe('Date formatting', () => {
 
     it('should call fallback method', () => {
       expect(formatDate(date)).toBe('lolo');
-      expect(fallback.getFallbackFormat).lastCalledWith(date, { timeZone: 'UTC' });
+      expect(fallback.getFallbackFormat).lastCalledWith(date, {});
     });
   });
 });

--- a/src/date/support-detection/toLocaleDateString.js
+++ b/src/date/support-detection/toLocaleDateString.js
@@ -21,7 +21,7 @@ function toLocaleDateStringSupportsLocales() {
 }
 
 function toLocaleDateStringReturnsCorrectValue() {
-  const date = new Date('2018-12-01');
-  const dateString = date.toLocaleDateString('en-GB', { timeZone: 'UTC' });
+  const date = new Date(2018, 11, 1);
+  const dateString = date.toLocaleDateString('en-GB');
   return dateString === '01/12/2018';
 }


### PR DESCRIPTION
Do not set UTC as default timezone for `formatDate`.

**Why?** 
First I thought that `date-lookup` (uses `formatDate`) should convert all input times to UTC midnight. Then I figured it causes issues in edge timezones (Fiji or Samoa, when non-UTC time is used `<DateLookup value="new Date()" .../>`).

Using users timezone makes `date-lookup` usage nicer (and makes more sense, its client side thingy), you can pass in `new Date()` etc instead of converted-to-UTC dates 

`formatDate` was added very recently and there should not be any other users.

**NB!** If anyone has strong opinions for keeping UTC as default then please explain and I'm ok to delete the PR.