### PR TITLE
Allow formatting of zero values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.4.2
+## Fix zero value formatting
+
 # v1.4.1
 ## Fix typo in README.md and in CHANGELOG.md
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A library for formatting things, like dates and currencies and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/currency/currency.spec.js
+++ b/src/currency/currency.spec.js
@@ -43,6 +43,10 @@ describe('Currency formatting', () => {
     expect(formatMoney(1234.5, 'gbp')).toBe('1,234.50 GBP');
   });
 
+  it('formats money when passed zero values', () => {
+    expect(formatMoney(0, 'gbp')).toBe('0 GBP');
+  });
+
   function reloadFormatting() {
     jest.resetModules();
     // eslint-disable-next-line global-require

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -40,7 +40,7 @@ function getPrecisionOptions(precision) {
  * @returns {String}
  */
 export function formatNumber(number, locale = DEFAULT_LOCALE, precision) {
-  if (!number) {
+  if (!number && number !== 0) {
     return null;
   }
 

--- a/src/number/number.spec.js
+++ b/src/number/number.spec.js
@@ -48,6 +48,26 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         expect(formatNumber(number, 'en-GB')).toEqual('1,234.56');
       });
     });
+
+    describe('and given a zero valued number', () => {
+      beforeEach(() => {
+        number = 0.0;
+      });
+
+      it('should format the value', () => {
+        expect(formatNumber(number, 'en-GB')).toEqual('0');
+      });
+    });
+
+    describe('and given a string zero valued number', () => {
+      beforeEach(() => {
+        number = '0';
+      });
+
+      it('should format the value', () => {
+        expect(formatNumber(number, 'en-GB')).toEqual('0');
+      });
+    });
   });
 
   describe('when es-ES locale supplied', () => {
@@ -116,14 +136,49 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
   });
 
   describe('when a precision is supplied', () => {
-    beforeEach(() => {
+    beforeAll(() => {
       locale = DEFAULT_LOCALE;
-      number = '1234.5';
       precision = 2;
     });
 
-    it('should format the value with the correct decimals', () => {
-      expect(formatNumber(number, locale, precision)).toEqual('1,234.50');
+    describe('and given a value with decimals', () => {
+      beforeEach(() => {
+        number = '1234.5';
+      });
+
+      it('should format the value with the expected fixed precision', () => {
+        expect(formatNumber(number, locale, precision)).toEqual('1,234.50');
+      });
+    });
+
+    describe('and given a value with no decimals', () => {
+      beforeEach(() => {
+        number = 10;
+      });
+
+      it('should format the value with the expected fixed precision', () => {
+        expect(formatNumber(number, locale, precision)).toEqual('10.00');
+      });
+    });
+
+    describe('and given a zero value', () => {
+      beforeEach(() => {
+        number = 0;
+      });
+
+      it('should format the value with the expected fixed precision', () => {
+        expect(formatNumber(number, locale, precision)).toEqual('0.00');
+      });
+    });
+
+    describe('and given an undefined value', () => {
+      beforeEach(() => {
+        number = undefined;
+      });
+
+      it('should return null', () => {
+        expect(formatNumber(number, locale, precision)).toEqual(null);
+      });
     });
   });
 });


### PR DESCRIPTION
We have various use cases where we want to pass zero valued numbers, but would still like them formatted in a consistent way.

E.g A zero valued fee in comparison: https://transferwise.com/gb/compare/

```
[0 - value] [EUR - currency] [ES - lang / locale]
```

Should ideally render as:

```
0,00 EUR
```

Today it will return:

```
null EUR
```