### PR TITLE
Add ability to format currencies with an alwaysShowDecimals option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.5.0
+## Add ability to format currencies with alwaysShowDecimals option
+
 # v1.4.3
 ## Checking number formatting locales for validity
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A library for formatting things, like dates and currencies and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/currency/currency.js
+++ b/src/currency/currency.js
@@ -43,23 +43,36 @@ function amountHasNoDecimals(amount) {
   return amount % 1 === 0;
 }
 
-function getPrecision(amount, currencyCode) {
-  if (amountHasNoDecimals(amount)) {
+function getPrecision(amount, currencyCode, alwaysShowDecimals) {
+  if (amountHasNoDecimals(amount) && !alwaysShowDecimals) {
     return 0;
   }
+
   return getCurrencyDecimals(currencyCode);
 }
 
-export function formatAmount(amount, currencyCode, locale = DEFAULT_LOCALE) {
-  const precision = getPrecision(amount, currencyCode);
+export function formatAmount(
+  amount,
+  currencyCode,
+  locale = DEFAULT_LOCALE,
+  options = { alwaysShowDecimals: false },
+) {
+  const availablePrecision = getPrecision(amount, currencyCode, options.alwaysShowDecimals);
   const isNegative = amount < 0;
   const absoluteAmount = Math.abs(amount);
 
-  const formattedAbsoluteAmount = formatNumber(absoluteAmount, locale, precision);
+  const formattedAbsoluteAmount = formatNumber(absoluteAmount, locale, availablePrecision);
 
   return isNegative ? `- ${formattedAbsoluteAmount}` : formattedAbsoluteAmount;
 }
 
-export function formatMoney(amount, currencyCode, locale = DEFAULT_LOCALE) {
-  return `${formatAmount(amount, currencyCode, locale)} ${(currencyCode || '').toUpperCase()}`;
+export function formatMoney(
+  amount,
+  currencyCode,
+  locale = DEFAULT_LOCALE,
+  options = { alwaysShowDecimals: false },
+) {
+  return `${formatAmount(amount, currencyCode, locale, options)} ${(
+    currencyCode || ''
+  ).toUpperCase()}`;
 }

--- a/src/currency/currency.spec.js
+++ b/src/currency/currency.spec.js
@@ -47,6 +47,50 @@ describe('Currency formatting', () => {
     expect(formatMoney(0, 'gbp')).toBe('0 GBP');
   });
 
+  describe('when different levels of precision are given', () => {
+    let currency;
+
+    describe('with a currency supporting a precision level of 2 decimals', () => {
+      beforeEach(() => {
+        currency = 'gbp';
+      });
+
+      it('formats money given 3 decimals', () => {
+        expect(formatMoney(1.111, currency, 'en')).toBe('1.11 GBP');
+      });
+
+      it('formats money given 2 decimals', () => {
+        expect(formatMoney(1.11, currency, 'en')).toBe('1.11 GBP');
+      });
+
+      it('formats money given 1 decimal', () => {
+        expect(formatMoney(1.1, currency, 'en')).toBe('1.10 GBP');
+      });
+
+      it('formats money with no decimals without alwaysShowDecimals option', () => {
+        expect(formatMoney(1, currency, 'en')).toBe('1 GBP');
+      });
+
+      it('formats money with no decimals, when given alwaysShowDecimals option', () => {
+        expect(formatMoney(1, currency, 'en', { alwaysShowDecimals: true })).toBe('1.00 GBP');
+      });
+    });
+
+    describe('with a currency supporting a precision level of 0 decimals', () => {
+      beforeEach(() => {
+        currency = 'huf';
+      });
+
+      it('formats money without options', () => {
+        expect(formatMoney(1.111, currency, 'en')).toBe('1 HUF');
+      });
+
+      it('formats money when given alwaysShowDecimals option', () => {
+        expect(formatMoney(1.11, currency, 'en', { alwaysShowDecimals: true })).toBe('1 HUF');
+      });
+    });
+  });
+
   function reloadFormatting() {
     jest.resetModules();
     // eslint-disable-next-line global-require


### PR DESCRIPTION
For full context see:

https://github.com/transferwise/formatting/issues/17

In short, adds option to format currency values with no decimals with the default level of precision regardless of whether the decimal amount is not zero. This is achieved via a 'alwaysShowDecimals' option.

E.g can now format [3] [GBP]

As:

'3.00 GBP' instead of the current only option of '3 GBP'