### PR TITLE
ASIA-2017: Tweak rate formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 Do you use `getRateInAllFormats(...)` (introduced in v1.6.0)?
 
 - **No** -> Nothing to do, upgrading is safe and will not break anything.
-- **Yes** -> `getRateInAllFormat(...)`'s response has some renamed properties, check https://github.com/transferwise/formatting/pull/22#issue-283516357.
+- **Yes** -> `getRateInAllFormats(...)`'s response has some renamed properties, check https://github.com/transferwise/formatting/pull/22#issue-283516357.
 
 # v1.6.0
 ## Add ability to format rate for weaker currencies in inverted form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-# v1.7.0
-## Tweak rate formatter API for easier usage
+# v2.0.0
+## Change rate formatter API for easier usage
+
+### How to migrate from v1 to v2
+
+Do you use `getRateInAllFormats(...)`?
+
+- **No** -> Nothing to do, upgrading is safe and will not break anything.
+- **Yes** -> `getRateInAllFormat(...)`'s response has some renamed properties, check https://github.com/transferwise/formatting/pull/22#issue-283516357.
 
 # v1.6.0
 ## Add ability to format rate for weaker currencies in inverted form.
-
-Superseded by v1.7.0, please use that instead.
 
 # v1.5.0
 ## Add ability to format currencies with alwaysShowDecimals option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+# v1.7.0
+## Tweak rate formatter API for easier usage
+
 # v1.6.0
 ## Add ability to format rate for weaker currencies in inverted form.
+
+Superseded by v1.7.0, please use that instead.
 
 # v1.5.0
 ## Add ability to format currencies with alwaysShowDecimals option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### How to migrate from v1 to v2
 
-Do you use `getRateInAllFormats(...)`?
+Do you use `getRateInAllFormats(...)` (introduced in v1.6.0)?
 
 - **No** -> Nothing to do, upgrading is safe and will not break anything.
 - **Yes** -> `getRateInAllFormat(...)`'s response has some renamed properties, check https://github.com/transferwise/formatting/pull/22#issue-283516357.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Here's an example of the entire object that's returned from calling `getRateInAl
 }
 ```
 
-An optional `options` object can be passed as the last argument. Available options are:
+An optional `options` object can be passed as the last argument to `getRateInAllFormats`. Available options are:
 
 Option | Default | Allowed | Description
 -- | -- | -- | --
@@ -101,7 +101,7 @@ Option | Default | Allowed | Description
 `referenceMultiplier` | Depends on currency, but usually 1 | Any number, but typically 1, 10, 100, 1000, etc. | Controls the amount of the left-hand reference currency. Currency norms for the default are [configured here](./src/rate/config.js).
 `significantFigures` | 6 | Any positive integer | Controls the displayed precision of calculated values.
 
-Thus, depending on your needs, it's possible to get your rate in any of this formats:
+Thus, depending on your needs, it's possible to get your rate in any of these formats:
 
 _(Assume a from-VND transfer)_
 
@@ -114,14 +114,16 @@ _(Assume a from-VND transfer)_
 
 _**When does `getRateInAllFormats` suggest a decimal format, and when does it suggest an equation format?**_
 
-Keep in mind that historically before `getRateInAllFormats` existed, we were always showing the rate as a 1-source-unit-to-target decimal. Then, because that ended up in inscrutable rates when the source currency was tiny relative to the target (e.g. how does a customer work with `0.0000332345`?), we introduced `getRateInAllFormats` to provide an alternative presentation in pairs where the existing decimal was not working out.
+Keep in mind that historically before `getRateInAllFormats` existed, we were always showing the rate as a 1-source-unit-to-target decimal.
+
+Then, because that ended up in inscrutable rates when the source currency was tiny relative to the target (e.g. how does a customer work with `0.0000332345`?), we introduced `getRateInAllFormats` to provide an alternative presentation in pairs where the existing decimal was not working out.
 
 With that in mind, to preserve the old behaviour for typical currencies, `getRateInAllFormats` will therefore continue to suggest the decimal format in the 1-source-unit-to-target scenario. In other words, when:
 
 1. the resulting `reference` is `'source'` (whether calculated by currency norms, or explicitly overriden by the user), and
 2. the resulting `referenceMultiplier` is 1 (whether calculated by currency norms, or explicitly overriden by the user)
 
-If at least 1 of this conditions is not true, then it will suggest the equation format.
+If at least 1 of these conditions are not true, then it will suggest the equation format.
 
 ### Percentage formatting
 

--- a/README.md
+++ b/README.md
@@ -39,65 +39,89 @@ console.log(formatMoney(1234.56, 'EUR', 'en-GB' /* Optional, defaults to en-GB *
 
 ### Rate formatting
 
-### 1. formatRate(rate)
+#### formatRate(rate, options)
 ```js
-formatRate(0.08682346801) === "0.0868234"
+formatRate(0.08682346801) === "0.0868235"
+formatRate(0.08682346801, {significantFigures: 8}) === "0.086823468"
 ```
 
-The existing formatter. **Always guaranteed to return a string that's parseable as a number.** Old clients can continue to use it as it is. Technically they might see a "breaking change" in the form of switching from 5 decimal points to 6 significant figures, but we also want to include this optional change, because we believe that it'll practically improve things across the board, yet not make anything worse.
+Limits a rate to a certain amount of precision for display (6 significant figures by default). It will always return a numberstring (string that's parseable as a number).
 
-### 2. getRateInAllFormats(rate, sourceCurrency, targetCurrency, options)
+This is a dumb, low-level formatter for just the rate number value, and it's kept around mostly for older implementations. For typical rate display purposes, you may instead wish to make use of `getRateInAllFormats`, because it can suggest showing the rate inverted and/or multiplied if it makes sense for that currency pair.
+
+At the moment the only configurable option is `significantFigures`, you can set it if you don't like the default of 6 significant figures.
+
+#### getRateInAllFormats(rate, sourceCurrency, targetCurrency, options)
 
 ```js
-getRateInAllFormats(0.00230, 'BRL', 'USD', {}) === {
-  // Default format suggested based on the currency configuration and/or options passed
-  "default": {
+const rateFormats = getRateInAllFormats(0.00230, 'BRL', 'USD');
+
+// For countries with small-value currencies like BRL/JPY/INR, residents typically prefer the rate quoted with the target currency as the reference if it's stronger. E.g. Brazilians want to know how much BRL is 1 USD, rather than how much USD is 1 BRL.
+
+// A format that's appropriate for the currency pair will be suggested.
+rateFormats.formats[suggested.format].output // "1 USD = 434.783 BRL"
+// or simply...
+rateFormats.suggested.output // "1 USD = 434.783 BRL"
+
+// If you always want the equation format...
+rateFormats.formats.equation.output // "1 USD = 434.783 BRL"
+// If you always want the source-to-target number format (identical to formatRate(rate))...
+rateFormats.formats.decimal.output  // "0.00230000"
+```
+
+Here's an example of the entire object that's returned from calling `getRateInAllFormats`:
+
+```js
+{
+  "suggested": {
     "format": "equation", // either `equation` or `decimal`
     "output": "1 USD = 434.783 BRL",
-   },
+  },
 
-   "formats": {
-     "decimal": {
-       "output": "0.00230000", // Equivalent to the output of formatRate(rate)
-       "significantFigures": 6,
-     },
-     "equation": {
-       "output": "1 USD = 434.783 BRL",
-       "isInverted": true,
-       "rateInDecimal": "434.783", // formatted rate in the equation.
-       "rateMultiplier": 1,
-     },
-   }
+  "formats": {
+    "decimal": {
+      "output": "0.00230000", // Equivalent to the output of formatRate(rate)
+      "significantFigures": 6,
+    },
+    "equation": {
+      "output": "1 USD = 434.783 BRL",
+      "reference": "target", // a.k.a. which currency is the left-hand side.
+      "referenceMultiplier": 1 // a.k.a. left-hand anchor value.
+      "calculationInDecimal": "434.783", // a.k.a. right-hand value.
+    }
+  }
 }
 ```
-The options are below:
-```js
-options = {
-  reference: one of 'auto' (default), 'source', or 'target'
-  referenceMultiplier: a number (1 by default, 10 100 1000 etc. are typical alternatives),
-}
-```
-> You can think of **reference** being synonymous with the left-hand side of the equation pretty much.
 
-This method chooses whether we should be using an equationstring or a numberstring.
+An optional `options` object can be passed as the last argument. Available options are:
 
-##### Number Format
-Practically, it will choose a numberstring only in 1 specific case when both these conditions are true:
+Option | Default | Allowed | Description
+- | - | - | -
+`reference` | 'auto' | one of 'auto', 'source', or 'target' | Control which currency appears on the left-hand side as the reference. If 'auto' (the default), it will rely on currency norms [configured here](./src/rate/config.js).
+`referenceMultiplier` | Depends on currency, but usually 1 | Any number, but typically 1, 10, 100, 1000, etc. | Controls the amount of the left-hand reference currency. Currency norms for the default are [configured here](./src/rate/config.js).
+`significantFigures` | 6 | Any positive integer | Controls the displayed precision of calculated values.
 
-1. The `reference` currency happens to be the **source** currency *(ie: `hasInversionEnabled` is not set for `sourceCurrency` in [config.js](./src/rate/config.js) or `reference` option passed is not `target`), and*
-2. The `referenceMultiplier` happens to be **one.** *(ie: `multiplierForEquation` is not set for  `sourceCurrency` in [config.js](./src/rate/config.js) or `referenceMultiplier` option passed is equal than `1`)*
+Thus, depending on your needs, it's possible to get your rate in any of this formats:
 
-(It just happens that this specific case is also the majority case nowadays)
+_(Assume a from-VND transfer)_
 
-##### Equation Format
-These outputs are all possible equation outputs from this method: (assuming sending from-VND)
+- `"1 VND = 0.0000332345 GBP"` (equation)
+- `"100,000 VND = 3.32345 GBP"` (multiplied equation)
+- `"1 GBP = 30,382.67 VND"` (target-reference a.k.a. inverted equation)
+- `"100 HUF = 8,080.73 VND"` (inverted and multiplied equation)
+- `"0.0000332345"` (decimal)
+- `"30,382.67"` (inverted decimal)
 
-- `1 VND = 0.0000332345 GBP`
-- `100,000 VND = 3.32345 GBP` (multiplied)
-- `1 GBP = 30,382.67 VND` (inverted)
-- `100 HUF = 8,080.73 VND` (inverted and multiplied)
+_**When does `getRateInAllFormats` suggest a decimal format, and when does it suggest an equation format?**_
 
-Furthermore, depending on what you pass (or didn't pass) in `options` and currency specific configuration from [config.js](./src/rate/config.js), it would mean you could either let the formatter decide whether to invert and/or multiply, or override a particular choice yourself if necessary.
+Keep in mind that historically before `getRateInAllFormats` existed, we were always showing the rate as a 1-source-unit-to-target decimal. Then, because that ended up in inscrutable rates when the source currency was tiny relative to the target (e.g. how does a customer work with `0.0000332345`?), we introduced `getRateInAllFormats` to provide an alternative presentation in pairs where the existing decimal was not working out.
+
+With that in mind, to preserve the old behaviour for typical currencies, `getRateInAllFormats` will therefore continue to suggest the decimal format in the 1-source-unit-to-target scenario. In other words, when:
+
+1. the resulting `reference` is `'source'` (whether calculated by currency norms, or explicitly overriden by the user), and
+2. the resulting `referenceMultiplier` is 1 (whether calculated by currency norms, or explicitly overriden by the user)
+
+If at least 1 of this conditions is not true, then it will suggest the equation format.
 
 ### Percentage formatting
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Here's an example of the entire object that's returned from calling `getRateInAl
 An optional `options` object can be passed as the last argument. Available options are:
 
 Option | Default | Allowed | Description
-- | - | - | -
+-- | -- | -- | --
 `reference` | 'auto' | one of 'auto', 'source', or 'target' | Control which currency appears on the left-hand side as the reference. If 'auto' (the default), it will rely on currency norms [configured here](./src/rate/config.js).
 `referenceMultiplier` | Depends on currency, but usually 1 | Any number, but typically 1, 10, 100, 1000, etc. | Controls the amount of the left-hand reference currency. Currency norms for the default are [configured here](./src/rate/config.js).
 `significantFigures` | 6 | Any positive integer | Controls the displayed precision of calculated values.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ console.log(formatMoney(1234.56, 'EUR', 'en-GB' /* Optional, defaults to en-GB *
 
 ### Rate formatting
 
-#### formatRate(rate, options)
+#### formatRate(rate, [options])
 ```js
 formatRate(0.08682346801) === "0.0868235"
 formatRate(0.08682346801, {significantFigures: 8}) === "0.086823468"
@@ -51,7 +51,7 @@ This is a dumb, low-level formatter for just the rate number value, and it's kep
 
 At the moment the only configurable option is `significantFigures`, you can set it if you don't like the default of 6 significant figures.
 
-#### getRateInAllFormats(rate, sourceCurrency, targetCurrency, options)
+#### getRateInAllFormats(rate, sourceCurrency, targetCurrency, [options])
 
 ```js
 const rateFormats = getRateInAllFormats(0.00230, 'BRL', 'USD');
@@ -114,16 +114,12 @@ _(Assume a from-VND transfer)_
 
 _**When does `getRateInAllFormats` suggest a decimal format, and when does it suggest an equation format?**_
 
-Keep in mind that historically before `getRateInAllFormats` existed, we were always showing the rate as a 1-source-unit-to-target decimal.
-
-Then, because that ended up in inscrutable rates when the source currency was tiny relative to the target (e.g. how does a customer work with `0.0000332345`?), we introduced `getRateInAllFormats` to provide an alternative presentation in pairs where the existing decimal was not working out.
-
-With that in mind, to preserve the old behaviour for typical currencies, `getRateInAllFormats` will therefore continue to suggest the decimal format in the 1-source-unit-to-target scenario. In other words, when:
+To avoid changing the behaviour of many existing currency pairs, `getRateInAllFormats` will suggest the decimal format (which is what we've historically shown) when:
 
 1. the resulting `reference` is `'source'` (whether calculated by currency norms, or explicitly overriden by the user), and
 2. the resulting `referenceMultiplier` is 1 (whether calculated by currency norms, or explicitly overriden by the user)
 
-If at least 1 of these conditions are not true, then it will suggest the equation format.
+These 2 conditions will typically be true for "strong" source currencies like GBP, EUR, USD, AUD, SGD, etc. If at least 1 of these conditions are not true, then it will suggest the equation format.
 
 ### Percentage formatting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3658,14 +3658,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3680,20 +3678,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3810,8 +3805,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3823,7 +3817,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3838,7 +3831,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3846,14 +3838,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3872,7 +3862,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3953,8 +3942,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3966,7 +3954,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4088,7 +4075,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3658,12 +3658,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3678,17 +3680,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3805,7 +3810,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3817,6 +3823,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3831,6 +3838,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3838,12 +3846,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3862,6 +3872,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3942,7 +3953,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3954,6 +3966,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4075,6 +4088,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@transferwise/formatting",
-  "version": "1.6.0",
-  "description": "A library for formatting things, like dates and currencies and the like.",
+  "version": "1.7.0",
+  "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {
     "precommit": "lint-staged",

--- a/src/rate/formatRate.js
+++ b/src/rate/formatRate.js
@@ -1,8 +1,5 @@
 import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
 
-export default function(
-  rate,
-  { numberOfSignificantDigits = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {},
-) {
-  return rate.toPrecision(numberOfSignificantDigits);
+export default function(rate, { significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {}) {
+  return rate.toPrecision(significantFigures);
 }

--- a/src/rate/formatRate.spec.js
+++ b/src/rate/formatRate.spec.js
@@ -9,8 +9,8 @@ describe('Rate formatting', () => {
   });
 
   it('formats rate given significant figures', () => {
-    expect(formatRate(1.23, { numberOfSignificantDigits: 5 })).toBe('1.2300');
-    expect(formatRate(111.23, { numberOfSignificantDigits: 7 })).toBe('111.2300');
-    expect(formatRate(0.000273, { numberOfSignificantDigits: 3 })).toBe('0.000273');
+    expect(formatRate(1.23, { significantFigures: 5 })).toBe('1.2300');
+    expect(formatRate(111.23, { significantFigures: 7 })).toBe('111.2300');
+    expect(formatRate(0.000273, { significantFigures: 3 })).toBe('0.000273');
   });
 });

--- a/src/rate/formatRateEquation.js
+++ b/src/rate/formatRateEquation.js
@@ -1,8 +1,12 @@
+import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
 import formatRate from './formatRate';
 import { formatAmount } from '../currency';
 
-export default function({ lhsValue, lhsCurrency, rhsValue, rhsCurrency }) {
-  return `${formatAmount(lhsValue, lhsCurrency)} ${lhsCurrency} = ${formatRate(
-    rhsValue,
-  )} ${rhsCurrency}`;
+export default function(
+  { lhsValue, lhsCurrency, rhsValue, rhsCurrency },
+  { significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {},
+) {
+  return `${formatAmount(lhsValue, lhsCurrency)} ${lhsCurrency} = ${formatRate(rhsValue, {
+    significantFigures,
+  })} ${rhsCurrency}`;
 }

--- a/src/rate/formatRateEquation.spec.js
+++ b/src/rate/formatRateEquation.spec.js
@@ -23,4 +23,23 @@ describe('Rate formatting', () => {
       }),
     ).toBe('10,000 IDR = 23.0000 USD');
   });
+
+  it.each([[8, '1 VND = 0.0023000000 USD'], [2, '1 VND = 0.0023 USD']])(
+    'formats rate equation with configurable (%i) significant figures',
+    (significantFigures, expected) => {
+      expect(
+        formatRateEquation(
+          {
+            lhsCurrency: 'VND',
+            lhsValue: 1,
+            rhsCurrency: 'USD',
+            rhsValue: 0.0023,
+          },
+          {
+            significantFigures,
+          },
+        ),
+      ).toBe(expected);
+    },
+  );
 });

--- a/src/rate/getRateEquation.spec.js
+++ b/src/rate/getRateEquation.spec.js
@@ -6,7 +6,7 @@ jest.mock('./config', () => ({
   IDR: { multiplierForEquation: 10000 },
 }));
 
-describe('Get Rate Equation', () => {
+describe('Get rate equation', () => {
   it('returns equation without inversion or multiplication', () => {
     expect(getRateEquation(0.0023, 'VND', 'USD')).toEqual({
       lhsCurrency: 'VND',

--- a/src/rate/getRateInAllFormats.js
+++ b/src/rate/getRateInAllFormats.js
@@ -1,4 +1,4 @@
-import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_RATE_MULTIPLIER } from '../defaults';
+import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
 import formatRate from './formatRate';
 import formatRateEquation from './formatRateEquation';
 import getRateEquation from './getRateEquation';
@@ -7,16 +7,20 @@ export default function(
   rate,
   sourceCurrency,
   targetCurrency,
-  { reference = 'auto', referenceMultiplier = null } = {},
+  {
+    reference = 'auto',
+    referenceMultiplier,
+    significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS,
+  } = {},
 ) {
   const response = {
-    default: {},
+    suggested: {},
     formats: {},
   };
 
   response.formats.decimal = {
-    output: formatRate(rate),
-    significantFigures: NUMBER_OF_RATE_SIGNIFICANT_DIGITS,
+    output: formatRate(rate, { significantFigures }),
+    significantFigures,
   };
 
   const equation = getRateEquation(rate, sourceCurrency, targetCurrency, {
@@ -25,22 +29,23 @@ export default function(
   });
 
   response.formats.equation = {
-    output: formatRateEquation(equation),
-    isInverted: equation.lhsCurrency !== sourceCurrency,
-    rateMultiplier: equation.lhsValue,
-    rateInDecimal: formatRate(equation.rhsValue),
+    output: formatRateEquation(equation, { significantFigures }),
+    reference: equation.lhsCurrency === sourceCurrency ? 'source' : 'target',
+    referenceMultiplier: equation.lhsValue,
+    calculationInDecimal: formatRate(equation.rhsValue, { significantFigures }),
   };
 
-  if (equation.lhsCurrency === sourceCurrency && equation.lhsValue === DEFAULT_RATE_MULTIPLIER) {
-    response.default = {
+  if (equation.lhsCurrency === sourceCurrency && equation.lhsValue === 1) {
+    response.suggested = {
       format: 'decimal',
       output: response.formats.decimal.output,
     };
   } else {
-    response.default = {
+    response.suggested = {
       format: 'equation',
       output: response.formats.equation.output,
     };
   }
+
   return response;
 }

--- a/src/rate/getRateInAllFormats.spec.js
+++ b/src/rate/getRateInAllFormats.spec.js
@@ -6,36 +6,104 @@ jest.mock('./config', () => ({
   IDR: { multiplierForEquation: 10000 },
 }));
 
-describe('Get Rate In All Formats', () => {
-  it('returns default output as decimal when reference is sourceCurrency and referenceMultiplier is 1', () => {
-    expect(getRateInAllFormats(23354.7, 'USD', 'VND').default).toEqual({
+describe('Get rate in all formats', () => {
+  it('returns suggested output as decimal when reference is sourceCurrency and referenceMultiplier is 1', () => {
+    expect(getRateInAllFormats(23354.7, 'USD', 'VND').suggested).toEqual({
       output: '23354.7',
       format: 'decimal',
     });
   });
 
-  it('returns default output as equation when reference is targetCurrency', () => {
-    expect(getRateInAllFormats(0.0023, 'BRL', 'USD').default).toEqual({
+  it('returns suggested output as equation when reference is targetCurrency', () => {
+    expect(getRateInAllFormats(0.0023, 'BRL', 'USD').suggested).toEqual({
       output: '1 USD = 434.783 BRL',
       format: 'equation',
     });
   });
 
-  it('returns default output as equation when referenceMultiplier is not 1', () => {
-    expect(getRateInAllFormats(0.0023, 'IDR', 'USD').default).toEqual({
+  it('returns suggested output as equation when referenceMultiplier is not 1', () => {
+    expect(getRateInAllFormats(0.0023, 'IDR', 'USD').suggested).toEqual({
       output: '10,000 IDR = 23.0000 USD',
       format: 'equation',
     });
   });
 
-  it('returns default output and other formats', () => {
+  it('returns suggested output and other formats', () => {
     const { formats } = getRateInAllFormats(0.0023, 'BRL', 'USD');
     expect(formats.equation).toEqual({
       output: '1 USD = 434.783 BRL',
-      isInverted: true,
-      rateInDecimal: '434.783',
-      rateMultiplier: 1,
+      reference: 'target',
+      referenceMultiplier: 1,
+      calculationInDecimal: '434.783',
     });
     expect(formats.decimal).toEqual({ output: '0.00230000', significantFigures: 6 });
+  });
+
+  it('allows configuring reference currency as an option', () => {
+    // 'auto' behaves the same as unpassed.
+    expect(getRateInAllFormats(9.8765, 'ABC', 'DEF', { reference: 'auto' })).toEqual(
+      getRateInAllFormats(9.8765, 'ABC', 'DEF'),
+    );
+
+    expect(getRateInAllFormats(9.8765, 'ABC', 'DEF', { reference: 'source' })).toMatchObject({
+      suggested: {
+        format: 'decimal',
+        output: '9.87650',
+      },
+      formats: {
+        equation: {
+          output: '1 ABC = 9.87650 DEF',
+          calculationInDecimal: '9.87650',
+        },
+        decimal: {
+          output: '9.87650',
+        },
+      },
+    });
+  });
+
+  it('allows configuring reference multiplier as an option', () => {
+    expect(getRateInAllFormats(9.8765, 'ABC', 'DEF', { referenceMultiplier: 10 })).toMatchObject({
+      suggested: {
+        format: 'equation',
+        output: '10 ABC = 98.7650 DEF',
+      },
+      formats: {
+        equation: {
+          output: '10 ABC = 98.7650 DEF',
+          calculationInDecimal: '98.7650',
+        },
+        decimal: {
+          output: '9.87650',
+        },
+      },
+    });
+  });
+
+  it('allows configuring significant figures as an option', () => {
+    expect(getRateInAllFormats(0.12345, 'ABC', 'DEF', { significantFigures: 4 })).toMatchObject({
+      formats: {
+        equation: {
+          output: '1 ABC = 0.1235 DEF',
+          calculationInDecimal: '0.1235',
+        },
+        decimal: {
+          output: '0.1235',
+          significantFigures: 4,
+        },
+      },
+    });
+    expect(getRateInAllFormats(0.12345, 'ABC', 'DEF', { significantFigures: 10 })).toMatchObject({
+      formats: {
+        equation: {
+          output: '1 ABC = 0.1234500000 DEF',
+          calculationInDecimal: '0.1234500000',
+        },
+        decimal: {
+          output: '0.1234500000',
+          significantFigures: 10,
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
Rewrite the readme for the rate formatter so it's easier for users to use ([read the revised rate section for the readme](https://github.com/transferwise/formatting/blob/a3fbcf7d70c660e056856da47a1c35abb114205b/README.md#rate-formatting)). At the same time, I saw that the API could benefit from a couple of renames to be more intuitive and consistent. 

:warning: This breaks the API relative to v1.6.0. But it's probably okay since v1.6.0 hasn't been adopted in the wild yet - We can get all users to avoid v1.6.0 and just upgrade to v1.7.0 (this version) directly. :warning:
 
**Proposed API changes:**

- Revamp properties for `getAllRateFormatters(...).formats.equation`. Reason being, it's easier for users if we can maintain parity between the input options we accept (reference and referenceMultiplier) and the resulting output properties where possible.
  - `isInverted` -> replaced with `reference`
  - `rateMultiplier` -> renames to `referenceMultiplier`
  - `rateInDecimal` -> renames to `calculationInDecimal`
- Rename `numberOfSignificantDigits` (secret option for `formatRate()`) to become the published option `significantFigures`. Same reason, in the output of `getAllRateFormatters`, the output property was named `significantFigures`, and we should try to maintain parity between input options and output properties where possible.
- `getRateInAllFormats`: Return a `suggested` format, instead of a `default` format. Saying `suggested` makes it clearer that this can suggest different things depending on the context. `suggested` also implies this is the "best" format, but `default` was missing such a connotation.