### PR TITLE
Temporarily avoid switch return fallthrough in rate logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.1
+## Rewrite getRateEquation to avoid a minification bug breaking getRateInAllFormats
+
 # v2.0.0
 ## Change rate formatter API for easier usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/rate/getRateEquation.js
+++ b/src/rate/getRateEquation.js
@@ -27,31 +27,28 @@ export default function(
   };
 
   function validateParameters() {
-    if (!rate || !sourceCurrency || !targetCurrency) {
-      throw new Error('Parameters rate, sourceCurrency and targetCurrency are mandatory');
-    }
+    if (!rate) throw new Error(`rate parameter is mandatory (got ${rate} instead).`);
+    if (!sourceCurrency)
+      throw new Error(`sourceCurrency parameter is mandatory (got ${sourceCurrency} instead).`);
+    if (!targetCurrency)
+      throw new Error(`targetCurrency parameter is mandatory (got ${targetCurrency} instead).`);
     if (referenceMultiplier && typeof referenceMultiplier !== 'number') {
-      throw new Error('referenceMultiplier must be a number');
+      throw new Error(
+        `referenceMultiplier must be a number (got ${typeof referenceMultiplier} ${referenceMultiplier} instead)`,
+      );
     }
     // Let shouldInvertEquation() handle `reference`.
   }
 }
 
 function shouldInvertEquation(referenceConfig, sourceCurrency) {
-  switch (referenceConfig) {
-    case 'source':
-      return false;
-    case 'target':
-      return true;
-    case 'auto':
-    case undefined:
-    case null:
-      return (config[sourceCurrency] || {}).hasInversionEnabled;
-    default:
-      throw new Error(
-        'Unrecognized reference config value (valid values are auto, source, target).',
-      );
-  }
+  if (referenceConfig === 'source') return false;
+  if (referenceConfig === 'target') return true;
+  if (['auto', undefined, null].indexOf(referenceConfig) > -1)
+    return (config[sourceCurrency] || {}).hasInversionEnabled;
+  throw new Error(
+    `Unrecognized reference config value: ${referenceConfig} (valid values are auto, source, target).`,
+  );
 }
 
 function getMultiplier(referenceMultiplierOverride, lhsCurrency) {


### PR DESCRIPTION
Temporary resolution for https://transferwise.slack.com/archives/CAWR6DDQX/p1562595131007400?thread_ts=1562343818.009000&cid=CAWR6DDQX

Terser plugin in a downstream user seems to have a bug minifying the previous switch-case-return construction in `shouldInvertEquation`. We'll try to surface a bug report to Terser, but in the meantime, Just rewrite it with `if`s instead so comparison and homepage can get on with their lives.

Also updated the neighbouring loggers, because we experienced on Friday that debugging on Friday could be frustrating when we could see the error message, but couldn't see what was the value that ended up causing the error message.