### PR TITLE
Localize rate equation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.1.0
+## Add formatNumberToSignificance to localize rate in getRateEquation
+
 # v2.0.1
 ## Rewrite getRateEquation to avoid a minification bug breaking getRateInAllFormats
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v2.1.0
-## Add formatNumberToSignificance to localize rate in getRateEquation
+## Add formatNumberToSignificantDigits to localize rate in getRateEquation
 
 # v2.0.1
 ## Rewrite getRateEquation to avoid a minification bug breaking getRateInAllFormats

--- a/README.md
+++ b/README.md
@@ -15,8 +15,23 @@ console.log(formatNumber(number, 'en-GB' /* Optional, defaults to en-GB */));
 // --> '123,456'
 console.log(formatNumber(number, 'es-ES', 0 /* Optional precision, defaults to 0 */));
 // --> '123.456'
-console.log(formatNumber(number, 'hu-HU'));
+console.log(formatNumber(number, 'hu-HU', 0, 'FractionDigits' /* Optional precision type (FractionDigits or SignificantDigits), defaults to 'FractionDigits' */ ));
 // --> '123 456'
+```
+
+`formatNumberToSignificantDigits` performs the same localization as `formatNumber`, but provides precision to significant digits instead of decimal precision. Used under the hood for localizing rates in `getRateInAllFormats`.
+
+```javascript
+import { formatNumberToSignificantDigits } from '@transferwise/formatting';
+
+const number = 123456;
+
+console.log(formatNumberToSignificantDigits(number, 'en-GB' /* Optional, defaults to en-GB */));
+// --> '123,456'
+console.log(formatNumberToSignificantDigits(number, 'es-ES', 8 /* Optional precision, defaults to 6 */));
+// --> '123.456,00'
+console.log(formatNumberToSignificantDigits(number, 'hu-HU', 8));
+// --> '123 456,00'
 ```
 
 ### Amount formatting
@@ -51,7 +66,7 @@ This is a dumb, low-level formatter for just the rate number value, and it's kep
 
 At the moment the only configurable option is `significantFigures`, you can set it if you don't like the default of 6 significant figures.
 
-#### getRateInAllFormats(rate, sourceCurrency, targetCurrency, [options])
+#### getRateInAllFormats(rate, sourceCurrency, targetCurrency, [options], locale)
 
 ```js
 const rateFormats = getRateInAllFormats(0.00230, 'BRL', 'USD');
@@ -65,7 +80,7 @@ rateFormats.suggested.output // "1 USD = 434.783 BRL"
 
 // If you always want the equation format...
 rateFormats.formats.equation.output // "1 USD = 434.783 BRL"
-// If you always want the source-to-target number format (identical to formatRate(rate))...
+// If you always want the source-to-target number format (identical to formatNumberToSignificantDigits(rate, locale, significantFigures))...
 rateFormats.formats.decimal.output  // "0.00230000"
 ```
 
@@ -80,7 +95,7 @@ Here's an example of the entire object that's returned from calling `getRateInAl
 
   "formats": {
     "decimal": {
-      "output": "0.00230000", // Equivalent to the output of formatRate(rate)
+      "output": "0.00230000", // Equivalent to the output of formatNumberToSignificantDigits(rate, locale, significantFigures)
       "significantFigures": 6,
     },
     "equation": {
@@ -111,6 +126,8 @@ _(Assume a from-VND transfer)_
 - `"100 HUF = 8,080.73 VND"` (inverted and multiplied equation)
 - `"0.0000332345"` (decimal)
 - `"30,382.67"` (inverted decimal)
+
+All outputted strings are localized using the provided `locale` (defaults to `en-GB`).
 
 _**When does `getRateInAllFormats` suggest a decimal format, and when does it suggest an equation format?**_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -1,5 +1,16 @@
 export const DEFAULT_LOCALE = 'en-GB';
-export const MIN_PRECISION = 0;
-export const MAX_PRECISION = 20;
+export const DEFAULT_PRECISION_TYPE = 'FractionDigits';
 export const NUMBER_OF_RATE_SIGNIFICANT_DIGITS = 6;
 export const DEFAULT_RATE_MULTIPLIER = 1;
+export const PRECISION_TYPES = {
+  SIGNIFICANT_DIGITS: {
+    TYPE: 'SignificantDigits',
+    MIN_PRECISION: 1,
+    MAX_PRECISION: 21,
+  },
+  FRACTION_DIGITS: {
+    TYPE: 'FractionDigits',
+    MIN_PRECISION: 0,
+    MAX_PRECISION: 20,
+  },
+};

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -2,7 +2,7 @@ export const DEFAULT_LOCALE = 'en-GB';
 export const DEFAULT_PRECISION_TYPE = 'FractionDigits';
 export const NUMBER_OF_RATE_SIGNIFICANT_DIGITS = 6;
 export const DEFAULT_RATE_MULTIPLIER = 1;
-export const PRECISION_TYPES = {
+export const PRECISION = {
   SIGNIFICANT_DIGITS: {
     TYPE: 'SignificantDigits',
     MIN_PRECISION: 1,

--- a/src/number/number-no-intl.spec.js
+++ b/src/number/number-no-intl.spec.js
@@ -1,5 +1,5 @@
 import { DEFAULT_LOCALE } from '../defaults';
-import { formatNumber, formatNumberToSignificance } from './number';
+import { formatNumber, formatNumberToSignificantDigits } from './number';
 import * as intl from './feature-detection/intl';
 
 describe('Number formatting, when Intl.NumberFormat is not supported', () => {
@@ -118,12 +118,12 @@ describe('Number formatting, when Intl.NumberFormat is not supported', () => {
       });
 
       it('should format the value with the correct decimals', () => {
-        expect(formatNumberToSignificance(number, locale, precision)).toEqual('1234.500000');
+        expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual('1234.500000');
       });
 
       it('should format smaller values with the correct decimals', () => {
         number = '0.025';
-        expect(formatNumberToSignificance(number, locale, precision)).toEqual('0.02500000000');
+        expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual('0.02500000000');
       });
     });
   });

--- a/src/number/number-no-intl.spec.js
+++ b/src/number/number-no-intl.spec.js
@@ -1,5 +1,5 @@
 import { DEFAULT_LOCALE } from '../defaults';
-import { formatNumber } from './number';
+import { formatNumber, formatNumberToSignificance } from './number';
 import * as intl from './feature-detection/intl';
 
 describe('Number formatting, when Intl.NumberFormat is not supported', () => {
@@ -110,6 +110,21 @@ describe('Number formatting, when Intl.NumberFormat is not supported', () => {
 
     it('should format the value with the correct decimals', () => {
       expect(formatNumber(number, locale, precision)).toEqual('1234.50');
+    });
+
+    describe('and is formatting to significant digits', () => {
+      beforeEach(() => {
+        precision = 10;
+      });
+
+      it('should format the value with the correct decimals', () => {
+        expect(formatNumberToSignificance(number, locale, precision)).toEqual('1234.500000');
+      });
+
+      it('should format smaller values with the correct decimals', () => {
+        number = '0.025';
+        expect(formatNumberToSignificance(number, locale, precision)).toEqual('0.02500000000');
+      });
     });
   });
 });

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -9,13 +9,10 @@ const formatters = {}; // cache, sample: { 'en-GB': formatter, 'en-GB2': formatt
  * Returns a formatter for the specified locale and NumberFormatOptions
  * @param {String} locale
  * @param {Intl.NumberFormatOptions} options
- * @param {String} precisionType - `FractionDigits|SignificantDigits` to differentiate formatters in cache
  * @returns {Intl.NumberFormat}
  */
-function getFormatter(locale, options, precisionType) {
-  const cacheKey = options
-    ? `${locale}${precisionType}${options[`minimum${precisionType}`]}`
-    : locale;
+function getFormatter(locale, options) {
+  const cacheKey = options ? `${locale}${Object.entries(options)}` : locale;
   if (!formatters[cacheKey]) {
     formatters[cacheKey] = options
       ? new Intl.NumberFormat(locale, options)
@@ -128,7 +125,7 @@ export function formatNumber(
   }
 
   const formatter = isPrecisionValid
-    ? getFormatter(validatedLocale, getPrecisionOptions(precision, precisionType), precisionType)
+    ? getFormatter(validatedLocale, getPrecisionOptions(precision, precisionType))
     : getFormatter(validatedLocale);
 
   return formatter.format(number);

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -60,8 +60,9 @@ function getValidLocale(locale) {
  * @returns {String}
  */
 function formatNumberWithFallback(number, precision, precisionType) {
-  if (precisionType === SIGNIFICANT_DIGITS.TYPE) return number.toPrecision(precision);
-  return number.toFixed(precision);
+  return precisionType === SIGNIFICANT_DIGITS.TYPE
+    ? number.toPrecision(precision)
+    : number.toFixed(precision);
 }
 
 /**

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, PRECISION } from '../defaults';
+import { DEFAULT_LOCALE, PRECISION, NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
 import { isIntlNumberFormatSupported } from './feature-detection';
 
 const { SIGNIFICANT_DIGITS, FRACTION_DIGITS } = PRECISION;
@@ -78,7 +78,7 @@ function formatNumberWithFallback(number, precision, precisionType) {
 export function formatNumberToSignificantDigits(
   number,
   locale = DEFAULT_LOCALE,
-  significantDigits,
+  significantDigits = NUMBER_OF_RATE_SIGNIFICANT_DIGITS,
 ) {
   return formatNumber(number, locale, significantDigits, SIGNIFICANT_DIGITS.TYPE);
 }

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -1,9 +1,7 @@
-import { DEFAULT_LOCALE, PRECISION_TYPES } from '../defaults';
+import { DEFAULT_LOCALE, PRECISION } from '../defaults';
 import { isIntlNumberFormatSupported } from './feature-detection';
 
-const { SIGNIFICANT_DIGITS, FRACTION_DIGITS } = PRECISION_TYPES;
-const { TYPE: SIGNIFICANT_DIGITS_TYPE } = SIGNIFICANT_DIGITS;
-const { TYPE: FRACTION_DIGITS_TYPE } = FRACTION_DIGITS;
+const { SIGNIFICANT_DIGITS, FRACTION_DIGITS } = PRECISION;
 
 const formatters = {}; // cache, sample: { 'en-GB': formatter, 'en-GB2': formatter }
 
@@ -65,7 +63,7 @@ function getValidLocale(locale) {
  * @returns {String}
  */
 function formatNumberWithFallback(number, precision, precisionType) {
-  if (precisionType === SIGNIFICANT_DIGITS_TYPE) return number.toPrecision(precision);
+  if (precisionType === SIGNIFICANT_DIGITS.TYPE) return number.toPrecision(precision);
   return number.toFixed(precision);
 }
 
@@ -78,7 +76,7 @@ function formatNumberWithFallback(number, precision, precisionType) {
  * @returns {String}
  */
 export function formatNumberToSignificance(number, locale = DEFAULT_LOCALE, significantDigits) {
-  return formatNumber(number, locale, significantDigits, SIGNIFICANT_DIGITS_TYPE);
+  return formatNumber(number, locale, significantDigits, SIGNIFICANT_DIGITS.TYPE);
 }
 
 /**
@@ -94,7 +92,7 @@ export function formatNumber(
   number,
   locale = DEFAULT_LOCALE,
   precision,
-  precisionType = FRACTION_DIGITS_TYPE,
+  precisionType = FRACTION_DIGITS.TYPE,
 ) {
   if (!number && number !== 0) {
     return null;
@@ -106,7 +104,7 @@ export function formatNumber(
   }
 
   const { MIN_PRECISION, MAX_PRECISION } =
-    precisionType === SIGNIFICANT_DIGITS_TYPE ? SIGNIFICANT_DIGITS : FRACTION_DIGITS;
+    precisionType === SIGNIFICANT_DIGITS.TYPE ? SIGNIFICANT_DIGITS : FRACTION_DIGITS;
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed#Parameters
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat#Parameters

--- a/src/number/number.js
+++ b/src/number/number.js
@@ -75,7 +75,11 @@ function formatNumberWithFallback(number, precision, precisionType) {
  * @param {String} locale
  * @returns {String}
  */
-export function formatNumberToSignificance(number, locale = DEFAULT_LOCALE, significantDigits) {
+export function formatNumberToSignificantDigits(
+  number,
+  locale = DEFAULT_LOCALE,
+  significantDigits,
+) {
   return formatNumber(number, locale, significantDigits, SIGNIFICANT_DIGITS.TYPE);
 }
 

--- a/src/number/number.spec.js
+++ b/src/number/number.spec.js
@@ -1,5 +1,5 @@
 import { DEFAULT_LOCALE } from '../defaults';
-import { formatNumber, formatNumberToSignificance } from './number';
+import { formatNumber, formatNumberToSignificantDigits } from './number';
 
 describe('Number formatting, when Intl.NumberFormat is supported', () => {
   let number = 123456;
@@ -229,7 +229,7 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         });
 
         it('should format the value with the expected fixed precision', () => {
-          expect(formatNumberToSignificance(number, locale, precision)).toEqual('1,234.50');
+          expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual('1,234.50');
         });
       });
 
@@ -239,7 +239,7 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         });
 
         it('should format the value with the expected fixed precision', () => {
-          expect(formatNumberToSignificance(number, locale, precision)).toEqual('10.0000');
+          expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual('10.0000');
         });
       });
 
@@ -249,7 +249,7 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         });
 
         it('should format the value with the expected fixed precision', () => {
-          expect(formatNumberToSignificance(number, locale, precision)).toEqual('0.00000');
+          expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual('0.00000');
         });
       });
 
@@ -259,7 +259,7 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         });
 
         it('should return null', () => {
-          expect(formatNumberToSignificance(number, locale, precision)).toEqual(null);
+          expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual(null);
         });
       });
     });

--- a/src/number/number.spec.js
+++ b/src/number/number.spec.js
@@ -223,6 +223,12 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
     });
 
     describe('and a precision is supplied', () => {
+      it('should format the value with the expected fixed precision', () => {
+        expect(formatNumberToSignificantDigits(1.23, locale, 5)).toBe('1.2300');
+        expect(formatNumberToSignificantDigits(111.23, locale, 7)).toBe('111.2300');
+        expect(formatNumberToSignificantDigits(0.000273, locale, 3)).toBe('0.000273');
+      });
+
       describe('and given a value with decimals', () => {
         beforeEach(() => {
           number = '1234.5';
@@ -261,6 +267,15 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
         it('should return null', () => {
           expect(formatNumberToSignificantDigits(number, locale, precision)).toEqual(null);
         });
+      });
+    });
+
+    describe('and a precision is not supplied', () => {
+      it('formats rate using default NUMBER_OF_RATE_SIGNIFICANT_DIGITS', () => {
+        expect(formatNumberToSignificantDigits(1.23, locale)).toBe('1.23000');
+        expect(formatNumberToSignificantDigits(111.23, locale)).toBe('111.230');
+        expect(formatNumberToSignificantDigits(10125.27, locale)).toBe('10,125.3');
+        expect(formatNumberToSignificantDigits(0.000273, locale)).toBe('0.000273000');
       });
     });
   });

--- a/src/number/number.spec.js
+++ b/src/number/number.spec.js
@@ -1,5 +1,5 @@
 import { DEFAULT_LOCALE } from '../defaults';
-import { formatNumber } from './number';
+import { formatNumber, formatNumberToSignificance } from './number';
 
 describe('Number formatting, when Intl.NumberFormat is supported', () => {
   let number = 123456;
@@ -213,6 +213,54 @@ describe('Number formatting, when Intl.NumberFormat is supported', () => {
 
       it('should return null', () => {
         expect(formatNumber(number, locale, precision)).toEqual(null);
+      });
+    });
+  });
+
+  describe('when formatting to significant figures', () => {
+    beforeAll(() => {
+      precision = 6;
+    });
+
+    describe('and a precision is supplied', () => {
+      describe('and given a value with decimals', () => {
+        beforeEach(() => {
+          number = '1234.5';
+        });
+
+        it('should format the value with the expected fixed precision', () => {
+          expect(formatNumberToSignificance(number, locale, precision)).toEqual('1,234.50');
+        });
+      });
+
+      describe('and given a value with no decimals', () => {
+        beforeEach(() => {
+          number = 10;
+        });
+
+        it('should format the value with the expected fixed precision', () => {
+          expect(formatNumberToSignificance(number, locale, precision)).toEqual('10.0000');
+        });
+      });
+
+      describe('and given a zero value', () => {
+        beforeEach(() => {
+          number = 0;
+        });
+
+        it('should format the value with the expected fixed precision', () => {
+          expect(formatNumberToSignificance(number, locale, precision)).toEqual('0.00000');
+        });
+      });
+
+      describe('and given an undefined value', () => {
+        beforeEach(() => {
+          number = undefined;
+        });
+
+        it('should return null', () => {
+          expect(formatNumberToSignificance(number, locale, precision)).toEqual(null);
+        });
       });
     });
   });

--- a/src/rate/formatRateEquation.js
+++ b/src/rate/formatRateEquation.js
@@ -1,12 +1,19 @@
-import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
-import formatRate from './formatRate';
+import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_LOCALE } from '../defaults';
+import { formatNumberToSignificance } from '../number';
 import { formatAmount } from '../currency';
 
 export default function(
   { lhsValue, lhsCurrency, rhsValue, rhsCurrency },
   { significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {},
+  locale = DEFAULT_LOCALE,
 ) {
-  return `${formatAmount(lhsValue, lhsCurrency)} ${lhsCurrency} = ${formatRate(rhsValue, {
+  return `${formatAmount(
+    lhsValue,
+    lhsCurrency,
+    locale,
+  )} ${lhsCurrency} = ${formatNumberToSignificance(
+    rhsValue,
+    locale,
     significantFigures,
-  })} ${rhsCurrency}`;
+  )} ${rhsCurrency}`;
 }

--- a/src/rate/formatRateEquation.js
+++ b/src/rate/formatRateEquation.js
@@ -1,5 +1,5 @@
 import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_LOCALE } from '../defaults';
-import { formatNumberToSignificance } from '../number';
+import { formatNumberToSignificantDigits } from '../number';
 import { formatAmount } from '../currency';
 
 export default function(
@@ -11,7 +11,7 @@ export default function(
     lhsValue,
     lhsCurrency,
     locale,
-  )} ${lhsCurrency} = ${formatNumberToSignificance(
+  )} ${lhsCurrency} = ${formatNumberToSignificantDigits(
     rhsValue,
     locale,
     significantFigures,

--- a/src/rate/getRateInAllFormats.js
+++ b/src/rate/getRateInAllFormats.js
@@ -1,4 +1,4 @@
-import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
+import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_LOCALE } from '../defaults';
 import formatRate from './formatRate';
 import formatRateEquation from './formatRateEquation';
 import getRateEquation from './getRateEquation';
@@ -12,6 +12,7 @@ export default function(
     referenceMultiplier,
     significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS,
   } = {},
+  locale = DEFAULT_LOCALE,
 ) {
   const response = {
     suggested: {},
@@ -29,7 +30,7 @@ export default function(
   });
 
   response.formats.equation = {
-    output: formatRateEquation(equation, { significantFigures }),
+    output: formatRateEquation(equation, { significantFigures }, locale),
     reference: equation.lhsCurrency === sourceCurrency ? 'source' : 'target',
     referenceMultiplier: equation.lhsValue,
     calculationInDecimal: formatRate(equation.rhsValue, { significantFigures }),

--- a/src/rate/getRateInAllFormats.js
+++ b/src/rate/getRateInAllFormats.js
@@ -1,5 +1,5 @@
 import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_LOCALE } from '../defaults';
-import formatRate from './formatRate';
+import { formatNumberToSignificantDigits } from '../number';
 import formatRateEquation from './formatRateEquation';
 import getRateEquation from './getRateEquation';
 
@@ -20,7 +20,7 @@ export default function(
   };
 
   response.formats.decimal = {
-    output: formatRate(rate, { significantFigures }),
+    output: formatNumberToSignificantDigits(rate, locale, significantFigures),
     significantFigures,
   };
 
@@ -33,7 +33,11 @@ export default function(
     output: formatRateEquation(equation, { significantFigures }, locale),
     reference: equation.lhsCurrency === sourceCurrency ? 'source' : 'target',
     referenceMultiplier: equation.lhsValue,
-    calculationInDecimal: formatRate(equation.rhsValue, { significantFigures }),
+    calculationInDecimal: formatNumberToSignificantDigits(
+      equation.rhsValue,
+      locale,
+      significantFigures,
+    ),
   };
 
   if (equation.lhsCurrency === sourceCurrency && equation.lhsValue === 1) {

--- a/src/rate/getRateInAllFormats.spec.js
+++ b/src/rate/getRateInAllFormats.spec.js
@@ -9,7 +9,7 @@ jest.mock('./config', () => ({
 describe('Get rate in all formats', () => {
   it('returns suggested output as decimal when reference is sourceCurrency and referenceMultiplier is 1', () => {
     expect(getRateInAllFormats(23354.7, 'USD', 'VND').suggested).toEqual({
-      output: '23354.7',
+      output: '23,354.7',
       format: 'decimal',
     });
   });


### PR DESCRIPTION
Discussion of change here: https://transferwise.slack.com/archives/C2SGDKP4Y/p1565187655193300

For context, the calculator isn't properly localising the rate in the equation string. We can't have an external solution like using `formatMoney/formatNumber` on the result, since the equation string `1 FOO = 2 BAR` isn't parsable as a number so returns `NaN`.

This PR extends `formatNumber` to accept a type of precision (`SignificantDigits|FractionDigits`) used by https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat). 

Currently the behaviour is `formatNumber` will take whatever precision is given and pass that to the `Intl.NumberFormat` constructor as the number of decimal places to show.

You'll now be able to pass in `SignificantDigits` as a fourth argument which will instead use that precision value to set the `minimumSignificantDigits/maximumSignificantDigits`.

It also exposes `formatNumberToSignificantDigits` which just wraps `formatNumber` and sets the precision type to `SignificantDigits` so consumers don't have to worry about that string value.

For the fallback value when `Intl.NumberFormat` isn't supported, `formatNumber` will continue to use `toFixed`, but will use `toPrecision` if the precision type is `SignificantDigits`