### PR TITLE
Make formatRate() function localizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.2.0
+## Make formatRate() function localizable
+
 # v2.1.0
 ## Add formatNumberToSignificantDigits to localize rate in getRateEquation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -966,6 +966,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -977,6 +978,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3637,7 +3639,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3658,12 +3661,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3678,17 +3683,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3805,7 +3813,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3817,6 +3826,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3831,6 +3841,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3838,12 +3849,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3862,6 +3875,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3942,7 +3956,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3954,6 +3969,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4039,7 +4055,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4075,6 +4092,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4094,6 +4112,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4137,12 +4156,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6888,7 +6909,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/rate/formatRate.js
+++ b/src/rate/formatRate.js
@@ -1,5 +1,10 @@
-import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS } from '../defaults';
+import { NUMBER_OF_RATE_SIGNIFICANT_DIGITS, DEFAULT_LOCALE } from '../defaults';
+import { formatNumberToSignificantDigits } from '../number';
 
-export default function(rate, { significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {}) {
-  return rate.toPrecision(significantFigures);
+export default function(
+  rate,
+  { significantFigures = NUMBER_OF_RATE_SIGNIFICANT_DIGITS } = {},
+  locale = DEFAULT_LOCALE,
+) {
+  return formatNumberToSignificantDigits(rate, locale, significantFigures);
 }

--- a/src/rate/formatRate.spec.js
+++ b/src/rate/formatRate.spec.js
@@ -1,10 +1,10 @@
 import formatRate from './formatRate';
 
-describe('Rate formatting', () => {
+describe('Rate formatting with no locale specified', () => {
   it('formats rate using default NUMBER_OF_RATE_SIGNIFICANT_DIGITS', () => {
     expect(formatRate(1.23)).toBe('1.23000');
     expect(formatRate(111.23)).toBe('111.230');
-    expect(formatRate(10125.27)).toBe('10125.3');
+    expect(formatRate(10125.27)).toBe('10,125.3');
     expect(formatRate(0.000273)).toBe('0.000273000');
   });
 
@@ -12,5 +12,29 @@ describe('Rate formatting', () => {
     expect(formatRate(1.23, { significantFigures: 5 })).toBe('1.2300');
     expect(formatRate(111.23, { significantFigures: 7 })).toBe('111.2300');
     expect(formatRate(0.000273, { significantFigures: 3 })).toBe('0.000273');
+  });
+});
+
+describe('when a locale is set', () => {
+  let originalNumberFormat;
+  let format;
+  let locale;
+
+  beforeAll(() => {
+    locale = 'some-LOCALE';
+
+    originalNumberFormat = Intl.NumberFormat;
+    format = number => jest.fn().mockReturnValue(`${number}Localized`)();
+    Intl.NumberFormat = jest.fn().mockImplementation(() => ({ format }));
+  });
+
+  afterAll(() => {
+    Intl.NumberFormat = originalNumberFormat;
+  });
+
+  it('formats rate using default NUMBER_OF_RATE_SIGNIFICANT_DIGITS with locale', () => {
+    expect(formatRate(657111.23, {})).toBe('657,111');
+    expect(formatRate(10125.27, {}, locale)).toBe('10125.27Localized');
+    expect(formatRate(0.000273, {}, locale)).toBe('0.000273Localized');
   });
 });


### PR DESCRIPTION
So far formatRate() doesn't take a locale as parameter so it'll always show the `.` as decimal separator.