### PR TITLE
MEA-1809: Adds UGX and KES to currencies with no fractional parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.4.3
+## Adds UGX and KES as currencies with no fractional parts
+
 # v2.4.2
 ## Bump for new translations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/formatting",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A library for formatting things, like dates, currencies, rates and the like.",
   "main": "./dist/formatting.js",
   "scripts": {

--- a/src/currency/currency.js
+++ b/src/currency/currency.js
@@ -21,6 +21,9 @@ const currencyDecimals = {
   // technically HUF does have decimals, but due to the exchange rate banks
   // do not accept decimal amounts
   HUF: 0,
+  UGX: 0,
+  // local banks do not consistently support the ideal 2-decimal places fractional part
+  KES: 0,
 
   BHD: 3,
   JOD: 3,


### PR DESCRIPTION
Adds UGX and KES to currencies with no fractional parts