### PR TITLE
Update release context to work on internal Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
           requires:
             - build
       - release:
-          context: frontend-publish
+          context: frontend-deploy-library
           requires:
             - test
           filters:


### PR DESCRIPTION
## Context

I recently moved this project to use our internal Circle CI, because the public Circle CI stopped functioning. The last release failed because the Circle contexts are named differently on internal.

### Changes

Updates the Circle context so that the Circle job has permission to release to NPM.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
